### PR TITLE
Updated volume mounting location within container scope to /srv/app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     ports: 
       - 8080:1337
     volumes:
-      - C:/srv/strapi:/usr/src/api/strapi-app
+      - C:/srv/strapi:/srv/app
 
   db:
     image: mariadb:latest


### PR DESCRIPTION
Currently the yml file mounts your local dick to "/usr/src/api/strapi-app" within the docker container. However this is not where the strapi file structure will be located within the docker container. Per the official Strapi docker hub image Strapi's files will be located at  "/srv/app"

More information available [here ](https://hub.docker.com/r/strapi/strapi)